### PR TITLE
Add two more types of table to target feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The above script outputs the following JSON.
   - [ ] Tables
     - [ ] Grid Tables
     - [ ] Simple Tables
+    - [ ] List tables
+    - [ ] CSV tables
   - [ ] Explicit Markup Blocks
     - [ ] Footnotes
       - [ ] Auto-Numbered Footnotes


### PR DESCRIPTION
RST supports four table types altogether, adding to list for completeness' sake.